### PR TITLE
Modified GruntFile to include Typescript build, added watch for types…

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,99 +10,116 @@
 
 'use strict';
 
-module.exports = function(grunt) {
+module.exports = function (grunt) {
 
 	/**
 	Load grunt plugins
 	@toc 2.
 	*/
-	grunt.loadNpmTasks('grunt-contrib-concat');
-	grunt.loadNpmTasks('grunt-contrib-uglify');
-	grunt.loadNpmTasks('grunt-contrib-jshint');
+    grunt.loadNpmTasks('grunt-typescript');
+    grunt.loadNpmTasks('grunt-contrib-concat');
+    grunt.loadNpmTasks('grunt-contrib-watch');
+    grunt.loadNpmTasks('grunt-contrib-uglify');
+    grunt.loadNpmTasks('grunt-contrib-jshint');
+    grunt.loadNpmTasks('grunt-contrib-connect');
+    grunt.loadNpmTasks('grunt-open');
+    grunt.loadNpmTasks('grunt-contrib-clean');
 
 	/**
 	Function that wraps everything to allow dynamically setting/changing grunt options and config later by grunt task. This init function is called once immediately (for using the default grunt options, config, and setup) and then may be called again AFTER updating grunt (command line) options.
 	@toc 3.
 	@method init
 	*/
-	function init(params) {
+    function init(params) {
 		/**
 		Project configuration.
 		@toc 5.
 		*/
-		grunt.initConfig({
-			concat: {
-				devCss: {
-					src:    [],
-					dest:   []
-				}
-			},
-			jshint: {
-				options: {
-					//force:          true,
-					globalstrict:   true,
-					//sub:            true,
-					node: true,
-					loopfunc: true,
-					browser:        true,
-					devel:          true,
-					globals: {
-						angular:    false,
-						$:          false,
-						moment:		false,
-						Pikaday: false,
-						module: false,
-						forge: false
-					}
-				},
-				beforeconcat:   {
-					options: {
-						force:	false,
-						ignores: ['**.min.js']
-					},
-					files: {
-						src: []
-					}
-				},
-				//quick version - will not fail entire grunt process if there are lint errors
-				beforeconcatQ:   {
-					options: {
-						force:	true,
-						ignores: ['**.min.js']
-					},
-					files: {
-						src: ['**.js']
-					}
-				}
-			},
-			uglify: {
-				options: {
-					mangle: false
-				},
-				build: {
-					files:  {},
-					src:    'lib/ng-lovefield.js',
-					dest:   'dest/ng-lovefield.min.js'
-				}
-			}/*,
-			karma: {
-				unit: {
-					configFile: publicPathRelativeRoot+'config/karma.conf.js',
-					singleRun: true,
-					browsers: ['PhantomJS']
-				}
-			}*/
-		});
-		
-		
-		/**
-		register/define grunt tasks
-		@toc 6.
-		*/
-		// Default task(s).
-		grunt.registerTask('default', ['jshint:beforeconcatQ', 'uglify:build']);
-	
-	}
-	init({});		//initialize here for defaults (init may be called again later within a task)
+        grunt.initConfig({
+            pkg: grunt.file.readJSON('package.json'),
+            connect: {
+                server: {
+                    options: {
+                        port: 8080,
+                        base: './'
+                    }
+                }
+            },
+            typescript: {
+                base: {
+                    src: ['lib/*.ts'],
+                    dest: 'dest/ng-lovefield.js',
+                    options: {
+                        module: 'amd',
+                        target: 'es5'
+                    }
+                }
+            },
+            clean: {
+                js: ['dest/*.js', 'lib/*.js', '!dest/*.min.js']
+            },
+
+            watch: {
+                files: 'lib/*.ts',
+                tasks: ['typescript', 'uglify:build']
+            },
+
+            open: {
+                dev: {
+                    path: 'http://localhost:8080/index.html'
+                }
+            },
+
+            concat: {
+                devCss: {
+                    src: [],
+                    dest: []
+                }
+            },
+
+            jshint: {
+                options: {
+                    //force:          true,
+                    globalstrict: true,
+                    //sub:            true,
+                    node: true,
+                    loopfunc: true,
+                    browser: true,
+                    devel: true,
+                    globals: {
+                        angular: false,
+                        $: false,
+                        moment: false,
+                        Pikaday: false,
+                        module: false,
+                        forge: false
+                    }
+                },
+                //quick version - will not fail entire grunt process if there are lint errors
+                beforeconcatQ: {
+                    options: {
+                        force: true,
+                        ignores: ['**.min.js']
+                    },
+                    files: {
+                        src: ['**.js']
+                    }
+                }
+            },
+            uglify: {
+                options: {
+                    mangle: false
+                },
+                build: {
+                    files: {},
+                    src: 'dest/ng-lovefield.js',
+                    dest: 'dest/ng-lovefield.min.js'
+                }
+            }
+        });
+
+        grunt.registerTask('default', ['jshint:beforeconcatQ', 'typescript', 'uglify:build', 'clean','connect', 'open', 'watch']);
+    }
+    init({});		//initialize here for defaults (init may be called again later within a task)
 
 };

--- a/package.json
+++ b/package.json
@@ -9,10 +9,16 @@
   },
   "devDependencies": {
     "express": "~3.4.4",
-    "grunt": "~0.4.1",
-    "grunt-contrib-concat": "~0.3.0",
-    "grunt-contrib-uglify": "~0.2.5",
-    "grunt-contrib-jshint": "~0.7.0"
+    "grunt": "^0.4.5",
+    "grunt-contrib-clean": "^1.0.0",
+    "grunt-contrib-concat": "^0.3.0",
+    "grunt-contrib-connect": "^0.11.2",
+    "grunt-contrib-jshint": "^0.7.2",
+    "grunt-contrib-uglify": "^0.2.7",
+    "grunt-contrib-watch": "^0.6.1",
+    "grunt-open": "^0.2.3",
+    "grunt-typescript": "^0.8.0",
+    "typescript": "^1.8.2"
   },
   "keywords": [
     "lovefield",


### PR DESCRIPTION
Added a bunch of grunt tasks and tweaked existing uglify script. Future changes in typescript should be easier to make.

```
    grunt.loadNpmTasks('grunt-typescript');
    grunt.loadNpmTasks('grunt-contrib-concat');
    grunt.loadNpmTasks('grunt-contrib-watch');
    grunt.loadNpmTasks('grunt-contrib-uglify');
    grunt.loadNpmTasks('grunt-contrib-jshint');
    grunt.loadNpmTasks('grunt-contrib-connect');
    grunt.loadNpmTasks('grunt-open');
    grunt.loadNpmTasks('grunt-contrib-clean');

```

Set default to:
`grunt.registerTask('default', ['jshint:beforeconcatQ', 'typescript', 'uglify:build', 'clean','connect', 'open', 'watch']);
`
